### PR TITLE
Connection, Parser: Support NOTIFY and UTF8=ACCEPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,5 @@ TODO
 Several things not yet implemented in no particular order:
 
 * Support additional IMAP commands/extensions:
-  * NOTIFY (via NOTIFY extension -- RFC5465)
   * STATUS addition to LIST (via LIST-STATUS extension -- RFC5819)
   * QRESYNC (RFC5162)

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -284,6 +284,12 @@ class Connection extends EventEmitter {
   serverSupports(cap) {
     return (this._caps && this._caps.indexOf(cap) > -1)
   }
+  serverEnabled(cap) {
+    return (this._enabled && this._enabled.indexOf(cap) > -1);
+  }
+  escapeBox(str) {
+    return escape(this.serverEnabled("UTF8=ACCEPT") ? (''+str) : utf7.encode(''+str));
+  }
   destroy() {
     this._queue = []
     this._curReq = undefined
@@ -310,7 +316,7 @@ class Connection extends EventEmitter {
       else
         options.mailbox = this._box.name
     }
-    let cmd = 'APPEND "' + escape(utf7.encode('' + options.mailbox)) + '"'
+    let cmd = 'APPEND "' + this.escapeBox(options.mailbox) + '"'
     if (options.flags) {
       if (!Array.isArray(options.flags))
         options.flags = [options.flags]
@@ -359,7 +365,7 @@ class Connection extends EventEmitter {
       cb = namespace
       namespace = ''
     }
-    namespace = escape(utf7.encode('' + namespace))
+    namespace = this.escapeBox(namespace)
     this._enqueue('LIST "' + namespace + '" "*"', cb)
   }
   id(identification, cb) {
@@ -392,7 +398,7 @@ class Connection extends EventEmitter {
       readOnly = false
     }
     name = '' + name
-    const encname = escape(utf7.encode(name))
+    const encname = this.escapeBox(name)
     let cmd = (readOnly ? 'EXAMINE' : 'SELECT'), self = this
     cmd += ' "' + encname + '"'
     if (this.serverSupports('CONDSTORE'))
@@ -445,13 +451,13 @@ class Connection extends EventEmitter {
     }
   }
   addBox(name, cb) {
-    this._enqueue('CREATE "' + escape(utf7.encode('' + name)) + '"', cb)
+    this._enqueue('CREATE "' + this.escapeBox(name) + '"', cb)
   }
   delBox(name, cb) {
-    this._enqueue('DELETE "' + escape(utf7.encode('' + name)) + '"', cb)
+    this._enqueue('DELETE "' + this.escapeBox(name) + '"', cb)
   }
   renameBox(oldname, newname, cb) {
-    const encoldname = escape(utf7.encode('' + oldname)), encnewname = escape(utf7.encode('' + newname)), self = this
+    const encoldname = this.escapeBox(oldname), encnewname = this.escapeBox(newname), self = this
     this._enqueue('RENAME "' + encoldname + '" "' + encnewname + '"', function (err) {
       if (err)
         return cb(err)
@@ -466,23 +472,23 @@ class Connection extends EventEmitter {
     })
   }
   subscribeBox(name, cb) {
-    this._enqueue('SUBSCRIBE "' + escape(utf7.encode('' + name)) + '"', cb)
+    this._enqueue('SUBSCRIBE "' + this.escapeBox(name) + '"', cb)
   }
   unsubscribeBox(name, cb) {
-    this._enqueue('UNSUBSCRIBE "' + escape(utf7.encode('' + name)) + '"', cb)
+    this._enqueue('UNSUBSCRIBE "' + this.escapeBox(name) + '"', cb)
   }
   getSubscribedBoxes(namespace, cb) {
     if (typeof namespace === 'function') {
       cb = namespace
       namespace = ''
     }
-    namespace = escape(utf7.encode('' + namespace))
+    namespace = this.escapeBox(namespace)
     this._enqueue('LSUB "' + namespace + '" "*"', cb)
   }
   status(boxName, cb) {
     if (this._box && this._box.name === boxName)
       throw new Error('Cannot call status on currently selected mailbox')
-    boxName = escape(utf7.encode('' + boxName))
+    boxName = this.escapeBox(boxName)
     let info = ['MESSAGES', 'RECENT', 'UNSEEN', 'UIDVALIDITY', 'UIDNEXT']
     if (this.serverSupports('CONDSTORE'))
       info.push('HIGHESTMODSEQ')
@@ -606,7 +612,7 @@ class Connection extends EventEmitter {
         + (which === '' ? 'sequence number' : 'uid')
         + 'list')
     }
-    boxTo = escape(utf7.encode('' + boxTo))
+    boxTo = this.escapeBox(boxTo)
     this._enqueue(which + 'COPY ' + uids.join(',') + ' "' + boxTo + '"', cb)
   }
   move(uids, boxTo, cb) {
@@ -625,7 +631,7 @@ class Connection extends EventEmitter {
           + 'list')
       }
       uids = uids.join(',')
-      boxTo = escape(utf7.encode('' + boxTo))
+      boxTo = this.escapeBox(boxTo)
       this._enqueue(which + 'MOVE ' + uids + ' "' + boxTo + '"', cb)
     }
     else if (this._box.permFlags.indexOf('\\Deleted') === -1
@@ -809,7 +815,7 @@ class Connection extends EventEmitter {
     if (!Array.isArray(labels))
       labels = [labels]
     labels = labels.map(function (v) {
-      return '"' + escape(utf7.encode('' + v)) + '"'
+      return '"' + this.escapeBox(v) + '"'
     }).join(' ')
     uids = uids.join(',')
     this._enqueue(which + 'STORE ' + uids + ' ' + mode
@@ -920,7 +926,7 @@ class Connection extends EventEmitter {
         triplets += ' '
       triplets += l + ' ' + limits[l]
     }
-    quotaRoot = escape(utf7.encode('' + quotaRoot))
+    quotaRoot = this.escapeBox(quotaRoot)
     this._enqueue('SETQUOTA "' + quotaRoot + '" (' + triplets + ')', function (err, quotalist) {
       if (err)
         return cb(err)
@@ -928,7 +934,7 @@ class Connection extends EventEmitter {
     })
   }
   getQuota(quotaRoot, cb) {
-    quotaRoot = escape(utf7.encode('' + quotaRoot))
+    quotaRoot = this.escapeBox(quotaRoot)
     this._enqueue('GETQUOTA "' + quotaRoot + '"', function (err, quotalist) {
       if (err)
         return cb(err)
@@ -936,7 +942,7 @@ class Connection extends EventEmitter {
     })
   }
   getQuotaRoot(boxName, cb) {
-    boxName = escape(utf7.encode('' + boxName))
+    boxName = this.escapeBox(boxName)
     this._enqueue('GETQUOTAROOT "' + boxName + '"', function (err, quotalist) {
       if (err)
         return cb(err)
@@ -997,8 +1003,14 @@ class Connection extends EventEmitter {
       this.namespaces = info.text
     else if (type === 'id')
       this._curReq.cbargs.push(info.text)
-    else if (type === 'capability')
+    else if (type === 'capability') {
       this._caps = info.text.map(function (v) { return v.toUpperCase() })
+    if (this.serverSupports('ENABLE'))
+      this._enqueue('ENABLE UTF8=ACCEPT CONDSTORE', function() {});
+    if (this.serverSupports('NOTIFY'))
+      this._enqueue('NOTIFY SET (SELECTED-DELAYED (MESSAGENEW (UID) MESSAGEEXPUNGE))', function() {});
+    } else if (type === 'enabled')
+      this._enabled = info.text.map(function(v) { return v.toUpperCase(); });
     else if (type === 'preauth')
       this.state = 'authenticated'
     else if (type === 'sort' || type === 'thread' || type === 'esearch')
@@ -1054,7 +1066,7 @@ class Connection extends EventEmitter {
 
     }
     else if (type === 'exists') {
-      if (!this._box && RE_OPENBOX.test(this._curReq.type))
+      if (!this._box && this._curReq && RE_OPENBOX.test(this._curReq.type))
         this._createCurrentBox()
       if (this._box) {
         let prev = this._box.messages.total, now = info.num
@@ -1183,7 +1195,7 @@ class Connection extends EventEmitter {
       this._curReq.cbargs.push(box)
     }
     else if (type === 'fetch') {
-      if (/^(?:UID )?FETCH/.test(this._curReq.fullcmd)) {
+      if (this._curReq && /^(?:UID )?FETCH/.test(this._curReq.fullcmd)) {
         // FETCH response sent as result of FETCH request
         const msg = this._curReq.fetchCache[info.num], keys = Object.keys(info.text), keyslen = keys.length
         let toget, msgEmitter, j

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -20,7 +20,7 @@ const CH_LF = 10,
   RE_SEQNO = /^\* (\d+)/,
   RE_LISTCONTENT = /^\((.*)\)$/,
   RE_LITERAL = /\{(\d+)\}$/,
-  RE_UNTAGGED = /^\* (?:(OK|NO|BAD|BYE|FLAGS|ID|LIST|XLIST|LSUB|SEARCH|STATUS|CAPABILITY|NAMESPACE|PREAUTH|SORT|THREAD|ESEARCH|QUOTA|QUOTAROOT)|(\d+) (EXPUNGE|FETCH|RECENT|EXISTS))(?:(?: \[([^\]]+)\])?(?: (.+))?)?$/i,
+  RE_UNTAGGED = /^\* (?:(OK|NO|BAD|BYE|FLAGS|ID|LIST|XLIST|LSUB|SEARCH|STATUS|CAPABILITY|ENABLED|NAMESPACE|PREAUTH|SORT|THREAD|ESEARCH|QUOTA|QUOTAROOT)|(\d+) (EXPUNGE|FETCH|RECENT|EXISTS))(?:(?: \[([^\]]+)\])?(?: (.+))?)?$/i,
   RE_TAGGED = /^A(\d+) (OK|NO|BAD) ?(?:\[([^\]]+)\] )?(.*)$/i,
   RE_CONTINUE = /^\+(?: (?:\[([^\]]+)\] )?(.+))?$/i,
   RE_CRLF = /\r\n/g,
@@ -219,6 +219,7 @@ class Parser extends EventEmitter {
       if (type === 'flags'
         || type === 'search'
         || type === 'capability'
+        || type === 'enabled'
         || type === 'sort') {
         if (m[5]) {
           if (type === 'search' && RE_SEARCH_MODSEQ.test(m[5])) {

--- a/test/test-connection-notify-utf8accept.js
+++ b/test/test-connection-notify-utf8accept.js
@@ -1,0 +1,92 @@
+var assert = require('assert'),
+    net = require('net'),
+    Imap = require('../lib/Connection'),
+    result;
+
+var CRLF = '\r\n';
+
+var RESPONSES = [
+  ['* CAPABILITY IMAP4rev1',
+   'A0 OK Thats all she wrote!',
+   ''
+  ].join(CRLF),
+  ['* CAPABILITY IMAP4rev1 ENABLE NOTIFY',
+   'A1 OK authenticated (Success)',
+   ''
+  ].join(CRLF),
+  ['* ENABLED',
+   'A2 OK Success',
+   ''
+  ].join(CRLF),
+  ['A3 OK Success',
+   ''
+  ].join(CRLF),
+  ['* LIST (\\Noselect) "/" "/"',
+   'A4 OK Success',
+   ''
+  ].join(CRLF),
+  ['* 941 EXISTS',
+   '* OK [UIDNEXT 486028] next uid',
+   '* 0 RECENT',
+   '* 941 EXISTS',
+   '* OK [UIDVALIDITY 5] uid validity',
+   '* OK [UNSEEN 144] first unseen',
+   'A5 OK [READ-ONLY] done',
+   ''
+  ].join(CRLF),
+  ['* 1 FETCH (UID 1 FLAGS () INTERNALDATE "01-Feb-2019 22:25:37 +0000")',
+   'A6 OK Success',
+   '* 2 FETCH (UID 2)',
+   '* 2 OK unsolicited untagged response like one from gmail',
+   ''
+  ].join(CRLF),
+  ['* LIST (\\Noselect) "/" "/"',
+   '* LIST () "/" "भारत"',
+   '* LIST () "/" "&-"',
+   'A7 OK Success',
+   ''
+  ].join(CRLF),
+  ['A8 OK Success',
+   ''
+  ].join(CRLF),
+];
+
+var srv = net.createServer(function(sock) {
+  sock.write('* OK asdf\r\n');
+  var buf = '', lines;
+  sock.on('data', function(data) {
+    buf += data.toString('utf8');
+    if (buf.indexOf(CRLF) > -1) {
+      lines = buf.split(CRLF);
+      buf = lines.pop();
+      lines.forEach(function() {
+        sock.write(RESPONSES.shift());
+      });
+    }
+  });
+});
+srv.listen(0, '127.0.0.1', function() {
+  var port = srv.address().port;
+  var imap = new Imap({
+    user: 'foo',
+    password: 'bar',
+    host: '127.0.0.1',
+    port: port,
+    keepalive: false
+  });
+  imap.on('ready', function() {
+    imap.openBox('INBOX', true, function () {
+      imap.fetch(1).on('end', function () {
+        imap.getBoxes(function(err, boxes) {
+          assert.deepEqual(Object.keys(boxes),
+                           [ '', 'भारत', '&' ]);
+          srv.close()
+          imap.end()
+        });
+      })
+    })
+  });
+  imap.connect();
+});
+
+


### PR DESCRIPTION
This also adds support for ENABLE.

NOTIFY (RFC 5465) just requires one elaborate command to set it up, the actual support requires nothing.

UTF8=ACCEPT (RFC 9755) works almost as well, the code already handled everything the server sends since javascript uses UTF8 for everything anyway. However, clients should send mailbox names as UTF8 rather than mUTF7 in commands, so this required a little bit of refactoring.